### PR TITLE
Prepare for PhpSpec 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To install this, make sure you are using the latest release of PHPSpec, and then
 ```json
 "require-dev": {
     ...,
-    "phpspec/nyan-formatters": "1.*"
+    "phpspec/nyan-formatters": "2.*"
 }
 ```
 
@@ -32,7 +32,7 @@ Install or update your dependencies, and then in a `phpspec.yml` file in the roo
 
 ```yaml
 extensions:
-    - PhpSpec\NyanFormattersExtension\Extension
+    PhpSpec\NyanFormattersExtension\Extension: ~
 ```
 
 Then, you can add a `--format` switch to your `phpspec` command with one of the following values:

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.3.3",
-        "phpspec/phpspec": "~2.0",
+        "phpspec/phpspec": "~3.0",
         "whatthejeff/nyancat-scoreboard": "~1.1"
     },
     "autoload": {

--- a/phpspec.yml.dist
+++ b/phpspec.yml.dist
@@ -1,2 +1,2 @@
 extensions:
-    - PhpSpec\NyanFormattersExtension\Extension
+    PhpSpec\NyanFormattersExtension\Extension: ~

--- a/src/PhpSpec/NyanFormattersExtension/Extension.php
+++ b/src/PhpSpec/NyanFormattersExtension/Extension.php
@@ -2,7 +2,7 @@
 
 namespace PhpSpec\NyanFormattersExtension;
 
-use PhpSpec\Extension\ExtensionInterface;
+use PhpSpec\Extension as PhpSpecExtension;
 use PhpSpec\ServiceContainer;
 
 /**
@@ -12,12 +12,12 @@ use PhpSpec\ServiceContainer;
  *
  * @author Matthew Davis <matt@mattdavis.co.uk>
  */
-class Extension implements ExtensionInterface
+class Extension implements PhpSpecExtension
 {
     /**
      * {@inheritdoc}
      */
-    public function load(ServiceContainer $container)
+    public function load(ServiceContainer $container, array $params)
     {
         $this->addFormatter($container, 'cat', 'PhpSpec\NyanFormattersExtension\Formatter\NyanFormatter');
         $this->addFormatter($container, 'dino', 'PhpSpec\NyanFormattersExtension\Formatter\DinoFormatter');
@@ -33,7 +33,7 @@ class Extension implements ExtensionInterface
      */
     protected function addFormatter(ServiceContainer $container, $name, $class)
     {
-        $container->set('formatter.formatters.nyan.' . $name, function ($c) use ($class) {
+        $container->define('formatter.formatters.nyan.' . $name, function ($c) use ($class) {
             /** @var ServiceContainer $c */
             return new $class(
                 $c->get('formatter.presenter'),

--- a/src/PhpSpec/NyanFormattersExtension/Formatter/NyanFormatter.php
+++ b/src/PhpSpec/NyanFormattersExtension/Formatter/NyanFormatter.php
@@ -4,7 +4,7 @@ namespace PhpSpec\NyanFormattersExtension\Formatter;
 
 use PhpSpec\Event\SuiteEvent;
 use PhpSpec\Event\ExampleEvent;
-use PhpSpec\Formatter\DotFormatter;
+use PhpSpec\Formatter\ConsoleFormatter;
 
 use NyanCat\Cat;
 use NyanCat\Rainbow;
@@ -21,7 +21,7 @@ use Fab\Factory as FabFactory;
  * @author Jeff Welch <whatthejeff@gmail.com>
  * @author Matthew Davis <matt@mattdavis.co.uk>
  */
-class NyanFormatter extends DotFormatter
+class NyanFormatter extends ConsoleFormatter
 {
     /**
      * The number of examples


### PR DESCRIPTION
Prepares the extension for PhpSpec 3

- Bumps version requirement to PhpSpec `~3.0` 
- Changes configuration file format
- Changes the extension interface
- Changes the service container load method definition
- Uses `$container->define` rather than `$container->set`
- Changes the formatter's superclass to `ConsoleFormatter`

@whatthejeff Could you review this please? I think it needs a new tag of 2.0 as this contains BC breaks if used with previous versions of PhpSpec.

@ciaranmcnulty @MarcelloDuarte Could you also take a look at this to ensure I haven't missed anything?

Thanks